### PR TITLE
uses small case for "novas" command

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -27,9 +27,9 @@ async function Main(appName: string, flag: string) {
       console.log(`NOVAS 1.0`);
     }
     else {
-      console.log(`To create a project, type:` + ` %cNOVAS create ` + `%c[project name]`, "color:#55dac8;", "color:red;");
-      console.log(`To compile a project, type:` + ` %cNOVAS build`, "color:#55dac8;");
-      console.log(`To start a dev server, type:` + ` %cNOVAS dev`, "color:#55dac8;");
+      console.log(`To create a project, type:` + ` %cnovas create ` + `%c[project name]`, "color:#55dac8;", "color:red;");
+      console.log(`To compile a project, type:` + ` %cnovas build`, "color:#55dac8;");
+      console.log(`To start a dev server, type:` + ` %cnovas dev`, "color:#55dac8;");
     }
   } catch (error) {
     if (!(error instanceof Deno.errors.NotFound)) {

--- a/commands/build.ts
+++ b/commands/build.ts
@@ -13,7 +13,7 @@ export const BuildProject = async (flag: string, cwd = Deno.cwd(), path = '/src/
   const memoized: { [key: string]: boolean } = {};
 
   if (flags["help"][flag]) {
-    console.log(`To run build, type:` + ` %NOVAS build`, "color:#55dac8");
+    console.log(`To run build, type:` + ` %novas build`, "color:#55dac8");
     return false;
   }
 

--- a/commands/build.ts
+++ b/commands/build.ts
@@ -13,7 +13,7 @@ export const BuildProject = async (flag: string, cwd = Deno.cwd(), path = '/src/
   const memoized: { [key: string]: boolean } = {};
 
   if (flags["help"][flag]) {
-    console.log(`To run build, type:` + ` %novas build`, "color:#55dac8");
+    console.log(`To run build, type:` + ` %cnovas build`, "color:#55dac8");
     return false;
   }
 

--- a/commands/create.ts
+++ b/commands/create.ts
@@ -10,7 +10,7 @@ import {
 
 export async function CreateProject(name: string, path: string, flag: string): Promise<boolean> {
   if (flags['help'][flag] || flags['help'][name]) {
-    console.log(`To create a project, type:` + ` %cNOVAS create ` + `%c[project name]`, "color:#55dac8;", "color:red;")
+    console.log(`To create a project, type:` + ` %cnovas create ` + `%c[project name]`, "color:#55dac8;", "color:red;")
     return false;
   }
   const appDir = `${path}/${name}`;


### PR DESCRIPTION
1. previous `NOVAS` command gives `command not found` error hence proposing these changes
![image](https://user-images.githubusercontent.com/47341981/192861983-caf19047-9a0c-44a8-b37e-715f1b3b5b65.png)

2. Adds missing `c` in order to get proper color for `novas build -h` command
![image](https://user-images.githubusercontent.com/47341981/192863606-3da28b8b-e4e7-44eb-bd6e-4aa6bafa5a2c.png)
